### PR TITLE
chore: use pre-commit/mirrors-clang-format instead

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
     hooks:
       - id: nbstripout
 
-  - repo: https://github.com/ssciwr/clang-format-hook
+  - repo: https://github.com/pre-commit/mirrors-clang-format
     rev: v13.0.0
     hooks:
       - id: clang-format


### PR DESCRIPTION
The original repository is being deprecated in favor of the automatically maintained https://github.com/pre-commit/mirrors-clang-format. See https://github.com/ssciwr/clang-format-hook.