### PR TITLE
Use pypi trusted publisher

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.12.1
+        uses: pypa/cibuildwheel@v2.15
 
       - uses: actions/upload-artifact@v3
         with:
@@ -22,6 +22,7 @@ jobs:
   upload_pypi:
     needs: [build-wheels]
     runs-on: ubuntu-latest
+    environment: release
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')
     steps:
       - uses: actions/download-artifact@v3
@@ -31,6 +32,4 @@ jobs:
 
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}
           verbose: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
       - id: mixed-line-ending
 
   - repo: https://github.com/psf/black
-    rev: 23.3.0
+    rev: 23.7.0
     hooks:
       - id: black
 
@@ -16,7 +16,7 @@ repos:
     rev: v0.6.13
     hooks:
       - id: cmake-format
-        additional_dependencies: [pyyaml==5.4.1]
+        additional_dependencies: [pyyaml]
 
   - repo: https://github.com/kynan/nbstripout
     rev: 0.6.1
@@ -29,7 +29,7 @@ repos:
       - id: clang-format
 
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.0.0-alpha.9-for-vscode
+    rev: v3.0.1
     hooks:
       - id: prettier
 ci:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,9 @@
-cmake_minimum_required(VERSION 3.15..3.25)
+cmake_minimum_required(VERSION 3.15..3.26)
 
 # Set a name and a version number for your project:
 project(
   pybind11-numpy-example
-  VERSION 0.0.5
+  VERSION 0.0.6
   LANGUAGES CXX)
 
 # Initialize some default paths

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "pybind11-numpy-example"
-version = "0.0.5"
+version = "0.0.6"
 description = "An example of using numpy with pybind11"
 readme = "README.md"
 license = {text = "MIT"}
@@ -18,6 +18,7 @@ classifiers=[
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
     "Operating System :: MacOS :: MacOS X",
@@ -41,4 +42,4 @@ BUILD_DOCS = "OFF"
 [tool.cibuildwheel]
 test-extras = "test"
 test-command = "python -m pytest {project}/python/tests -v"
-test-skip = "pp* *-musllinux* *-manylinux_i686"
+test-skip = "pp* *-musllinux* *-manylinux_i686 cp312-*"


### PR DESCRIPTION
- cibuildwheel -> 2.15 (builds python 3.12 wheels)
- set up repo as trusted publisher on pypi, remove API token
- bump version to 0.0.6
