### PR TITLE
Don't include c++ interface in Python wheel

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v4.6.0
     hooks:
       - id: check-yaml
       - id: end-of-file-fixer
@@ -8,7 +8,7 @@ repos:
       - id: mixed-line-ending
 
   - repo: https://github.com/psf/black
-    rev: 24.3.0
+    rev: 24.4.2
     hooks:
       - id: black
 
@@ -24,7 +24,7 @@ repos:
       - id: nbstripout
 
   - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: v18.1.2
+    rev: v18.1.5
     hooks:
       - id: clang-format
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.15..3.29)
 # Set a name and a version number for your project:
 project(
   pybind11-numpy-example
-  VERSION 0.0.12
+  VERSION 0.0.13
   LANGUAGES CXX)
 
 # Initialize some default paths
@@ -16,10 +16,11 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 # Configuration options
-option(BUILD_PYTHON "Enable building of Python bindings" ON)
+option(BUILD_CPP "Enable building of C++ interface" ON)
+option(BUILD_PYTHON "Enable building of Python interface" ON)
 option(BUILD_DOCS "Enable building of documentation" ON)
 
-# Build the c++ library
+# Build the core c++ library
 add_subdirectory(lib)
 
 # Build the c++ tests
@@ -35,31 +36,34 @@ if(BUILD_DOCS)
   add_subdirectory(doc)
 endif()
 
-# Build the python bindings
+# Build the python interface
 if(BUILD_PYTHON)
   add_subdirectory(src)
 endif()
 
-# Add an alias target for use if this project is included as a subproject in
-# another project
-add_library(pybind11_numpy_example::pybind11_numpy_example ALIAS
-            pybind11_numpy_example)
+# Install c++ interface
+if(BUILD_CPP)
+  # Add an alias target for use if this project is included as a subproject in
+  # another project
+  add_library(pybind11_numpy_example::pybind11_numpy_example ALIAS
+              pybind11_numpy_example)
 
-# Install targets and configuration
-install(
-  TARGETS pybind11_numpy_example
-  EXPORT pybind11_numpy_example_config
-  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+  # Install targets and configuration
+  install(
+    TARGETS pybind11_numpy_example
+    EXPORT pybind11_numpy_example_config
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
-install(
-  EXPORT pybind11_numpy_example_config
-  NAMESPACE pybind11_numpy_example::
-  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/pybind11_numpy_example)
+  install(
+    EXPORT pybind11_numpy_example_config
+    NAMESPACE pybind11_numpy_example::
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/pybind11_numpy_example)
 
-install(DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/include/
-        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+  install(DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/include/
+          DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+endif()
 
 # This prints a summary of found dependencies
 include(FeatureSummary)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "pybind11-numpy-example"
-version = "0.0.12"
+version = "0.0.13"
 description = "An example of using numpy with pybind11"
 readme = "README.md"
 license = {text = "MIT"}
@@ -12,7 +12,7 @@ authors=[{name="Liam Keegan", email="liam@keegan.ch"}]
 maintainers=[{name="Liam Keegan", email="liam@keegan.ch"}]
 requires-python = ">=3.7"
 dependencies = ["numpy"]
-keywords = ["pybind11", "cibuildwheel", "c++", "pypi", "numpy", "simple", "example"]
+keywords = ["pybind11", "cibuildwheel", "c++", "pypi", "numpy", "simple", "example", "wheel", "pypi", "conda-forge"]
 classifiers=[
     "Programming Language :: C++",
     "Programming Language :: Python :: 3 :: Only",
@@ -39,6 +39,7 @@ test = ["pytest"]
 docs = ["cmake", "breathe", "sphinx_rtd_theme"]
 
 [tool.scikit-build.cmake.define]
+BUILD_CPP = "OFF"
 BUILD_PYTHON = "ON"
 BUILD_TESTING = "OFF"
 BUILD_DOCS = "OFF"


### PR DESCRIPTION
- add `BUILD_CPP` cmake option
  - if enabled, c++ library is installed
  - enabled by default
- set `BUILD_CPP=OFF` in scikit-build-core config
- bump version
- resolves #39
